### PR TITLE
fix: shader error when loading InstanceedSkinnedMesh

### DIFF
--- a/src/core/entity/InstancedSkinnedMesh.js
+++ b/src/core/entity/InstancedSkinnedMesh.js
@@ -21,7 +21,7 @@ ShaderChunk.morphinstance_vertex = /* glsl */ `
         #ifdef MORPHTARGETS_COUNT
           ${ShaderChunk.morphinstance_vertex}
         #endif
-`;
+`
 ShaderChunk.skinning_pars_vertex = /* glsl */ `
         #ifdef USE_SKINNING
 

--- a/src/core/entity/InstancedSkinnedMesh.js
+++ b/src/core/entity/InstancedSkinnedMesh.js
@@ -17,6 +17,11 @@ const _identityMatrix = new Matrix4()
 
 const _instanceIntersects = []
 
+ShaderChunk.morphinstance_vertex = /* glsl */ `
+        #ifdef MORPHTARGETS_COUNT
+          ${ShaderChunk.morphinstance_vertex}
+        #endif
+`;
 ShaderChunk.skinning_pars_vertex = /* glsl */ `
         #ifdef USE_SKINNING
 


### PR DESCRIPTION
This PR fixes a shader compilation error when loading InstancedSkinnedMesh with three.js v162.
I believe this is a bug introduced in three.js v162.

This is probably is a temporary fix because:
- this bug was introduced in the currently latest three.js v162 (see PR https://github.com/mrdoob/three.js/pull/27669), so it is quite new, so there is a high chance they will fix this bug.
- three.js v162 added support for instanced meshes. There is a chance they will also add proper support for instanced skinned meshes soon.