### PR TITLE
Feat/better fog

### DIFF
--- a/src/core/game/game.js
+++ b/src/core/game/game.js
@@ -242,7 +242,7 @@ const camera = new PerspectiveCamera(
   60, // Field of view
   window.innerWidth / window.innerHeight, // Aspect ratio
   0.1, // Near clipping plane
-  2000, // Far clipping plane
+  3000, // Far clipping plane
 )
 const pool = create_pools(scene)
 
@@ -256,7 +256,7 @@ const get_state = last_event_value(events, 'STATE_UPDATED', INITIAL_STATE)
 const controller = new AbortController()
 
 scene.background = new Color('#000000')
-scene.fog = new Fog('#000000', 0, 1500)
+scene.fog = new Fog('#000000', 0.25 * camera.far, 0.98 * camera.far)
 
 renderer.setPixelRatio(window.devicePixelRatio)
 renderer.setSize(window.innerWidth, window.innerHeight)

--- a/src/core/modules/game_lights.js
+++ b/src/core/modules/game_lights.js
@@ -69,9 +69,7 @@ export default function () {
       }
 
       function update_sky_lights_color(sky_lights) {
-        scene.fog.color = sky_lights.fog.color
-          .clone()
-          .lerp(new Color('#000000'), 0.4)
+        scene.fog.color = sky_lights.fog.color.clone()
 
         directional_light.color = sky_lights.directional.color
         directional_light.intensity = sky_lights.directional.intensity

--- a/src/core/modules/game_sky.js
+++ b/src/core/modules/game_sky.js
@@ -174,10 +174,13 @@ export default function () {
 
         sky_lights_version = (sky_lights_version + 1) % 1000
 
+        const fog_color = new Color().lerpColors(new Color(0x61455), new Color(0xA1BDEB), smoothstep(sun_position.y, -0.12, 0.15))
+        fog_color.lerpColors(new Color(0xFFAB71), fog_color, smoothstep(Math.abs(sun_position.y - 0.0), 0, 0.15))
+
         const sky_lights = {
           version: sky_lights_version,
           fog: {
-            color: sun_color.clone(),
+            color: fog_color,
           },
           directional: {
             position:

--- a/src/core/modules/game_sky.js
+++ b/src/core/modules/game_sky.js
@@ -174,8 +174,16 @@ export default function () {
 
         sky_lights_version = (sky_lights_version + 1) % 1000
 
-        const fog_color = new Color().lerpColors(new Color(0x61455), new Color(0xA1BDEB), smoothstep(sun_position.y, -0.12, 0.15))
-        fog_color.lerpColors(new Color(0xFFAB71), fog_color, smoothstep(Math.abs(sun_position.y - 0.0), 0, 0.15))
+        const fog_color = new Color().lerpColors(
+          new Color(0x61455),
+          new Color(0xa1bdeb),
+          smoothstep(sun_position.y, -0.12, 0.15),
+        )
+        fog_color.lerpColors(
+          new Color(0xffab71),
+          fog_color,
+          smoothstep(Math.abs(sun_position.y - 0.0), 0, 0.15),
+        )
 
         const sky_lights = {
           version: sky_lights_version,

--- a/src/core/modules/game_terrain.js
+++ b/src/core/modules/game_terrain.js
@@ -130,7 +130,7 @@ export default function () {
           )
         }
 
-        terrain.setLod(camera.position, 50, 2000)
+        terrain.setLod(camera.position, 50, camera.far)
       })
     },
   }


### PR DESCRIPTION
This PR adjust fog so that it looks a bit better:
- synchronize fog distance with camera far plane, so that draw geometry is not wasted
- synchronize fog color with horizon color, so that the terrain blends nicely with the sky

Below, a before/after:
![image](https://github.com/aresrpg/aresrpg-dapp/assets/22922087/cd8a484a-92ff-4c66-a643-517b80c1a037)
