### PR TITLE
Feat/painting tweaks + water/ground level fixings

### DIFF
--- a/src/core/modules/game_terrain.js
+++ b/src/core/modules/game_terrain.js
@@ -10,7 +10,7 @@ import { abortable } from '../utils/iterator.js'
 import { current_character } from '../game/game.js'
 import proc_layers_json from '../../assets/terrain/proc_gen.json'
 import {
-  blocks_mapping,
+  blocks_colors,
   terrain_mapping,
 } from '../utils/terrain/world_settings.js'
 
@@ -26,11 +26,11 @@ export default function () {
     samplingScale: noise_scale,
     procLayers: proc_layers,
     terrainBlocksMapping: Object.values(terrain_mapping),
-    seaLevel: 75,
+    seaLevel: 76,
   }
 
   const map = {
-    voxelMaterialsList: Object.values(blocks_mapping).map(col => ({
+    voxelMaterialsList: Object.values(blocks_colors).map(col => ({
       color: new Color(col),
     })),
     getLocalMapData: async (block_start, block_end) => {
@@ -70,15 +70,17 @@ export default function () {
       }
     },
     sampleHeightmap(x, z) {
-      const ground_level = WorldGenerator.instance.getHeight(new Vector2(x, z))
-      const altitude = Math.max(ground_level, WorldGenerator.instance.seaLevel)
-      const block_type = WorldGenerator.instance.getBlock(
-        new Vector3(x, Math.floor(altitude - 0.5), z),
+      const raw_height = WorldGenerator.instance.getHeight(new Vector2(x, z))
+      const block_level = Math.max(
+        Math.floor(raw_height),
+        WorldGenerator.instance.seaLevel,
       )
-      const material = this.voxelMaterialsList[block_type]
+      const block_pos = new Vector3(x, block_level, z)
+      const block_type = WorldGenerator.instance.getBlockType(block_pos)
+      const block_color = new Color(blocks_colors[block_type])
       return {
-        altitude: Math.floor(altitude),
-        color: material.color,
+        altitude: block_level,
+        color: block_color,
       }
     },
   }

--- a/src/core/modules/game_terrain.js
+++ b/src/core/modules/game_terrain.js
@@ -70,14 +70,13 @@ export default function () {
       }
     },
     sampleHeightmap(x, z) {
-      const raw_height = WorldGenerator.instance.getHeight(new Vector2(x, z))
       const block_level =
-        Math.max(Math.floor(raw_height), WorldGenerator.instance.seaLevel) - 1
+        WorldGenerator.instance.getHeight(new Vector2(x, z)) - 1
       const block_pos = new Vector3(x, block_level, z)
       const block_type = WorldGenerator.instance.getBlockType(block_pos)
       const block_color = new Color(blocks_colors[block_type])
       return {
-        altitude: block_level,
+        altitude: block_level + 1,
         color: block_color,
       }
     },

--- a/src/core/modules/game_terrain.js
+++ b/src/core/modules/game_terrain.js
@@ -26,7 +26,7 @@ export default function () {
     samplingScale: noise_scale,
     procLayers: proc_layers,
     terrainBlocksMapping: Object.values(terrain_mapping),
-    seaLevel: 76,
+    seaLevel: 75,
   }
 
   const map = {
@@ -70,7 +70,8 @@ export default function () {
       }
     },
     sampleHeightmap(x, z) {
-      const altitude = WorldGenerator.instance.getHeight(new Vector2(x, z))
+      const ground_level = WorldGenerator.instance.getHeight(new Vector2(x, z))
+      const altitude = Math.max(ground_level, WorldGenerator.instance.seaLevel)
       const block_type = WorldGenerator.instance.getBlock(
         new Vector3(x, Math.floor(altitude - 0.5), z),
       )

--- a/src/core/modules/game_terrain.js
+++ b/src/core/modules/game_terrain.js
@@ -71,10 +71,8 @@ export default function () {
     },
     sampleHeightmap(x, z) {
       const raw_height = WorldGenerator.instance.getHeight(new Vector2(x, z))
-      const block_level = Math.max(
-        Math.floor(raw_height),
-        WorldGenerator.instance.seaLevel,
-      )
+      const block_level =
+        Math.max(Math.floor(raw_height), WorldGenerator.instance.seaLevel) - 1
       const block_pos = new Vector3(x, block_level, z)
       const block_type = WorldGenerator.instance.getBlockType(block_pos)
       const block_color = new Color(blocks_colors[block_type])

--- a/src/core/modules/player_movement.js
+++ b/src/core/modules/player_movement.js
@@ -64,9 +64,9 @@ export default function () {
 
       if (player.target_position) {
         const { x, z } = player.target_position
-        const block_pos = new Vector2(Math.floor(x), Math.floor(z)) // .subScalar(0.5)
-        const world_height = WorldGenerator.instance.getHeight(block_pos)
-        player.target_position.y = Math.floor(world_height)
+        const ground_pos = new Vector2(Math.floor(x), Math.floor(z)) // .subScalar(0.5)
+        const raw_height = WorldGenerator.instance.getRawHeight(ground_pos)
+        player.target_position.y = Math.floor(raw_height)
         player.move(player.target_position)
         player.target_position = null
 
@@ -162,9 +162,9 @@ export default function () {
 
       // const ground_height = HEIGHTFIELD(dummy.position.x, dummy.position.z)
       const { x, z } = dummy.position
-      const block_pos = new Vector2(Math.floor(x), Math.floor(z)) // .subScalar(0.5)
-      const world_height = WorldGenerator.instance.getHeight(block_pos)
-      const ground_height = Math.floor(world_height)
+      const ground_pos = new Vector2(Math.floor(x), Math.floor(z)) // .subScalar(0.5)
+      const raw_height = WorldGenerator.instance.getRawHeight(ground_pos)
+      const ground_height = Math.floor(raw_height)
 
       if (!ground_height) return
 

--- a/src/core/utils/terrain/world_settings.js
+++ b/src/core/utils/terrain/world_settings.js
@@ -18,29 +18,57 @@ export const terrain_mapping = {
   sea: {
     blockType: BlockType.WATER,
     threshold: 0,
+    randomness: {
+      low: 0,
+      high: 0,
+    },
   },
   beach: {
     blockType: BlockType.SAND,
     threshold: 75,
+    randomness: {
+      low: 0,
+      high: 5,
+    },
   },
   cliff: {
     blockType: BlockType.ROCK,
     threshold: 84,
+    randomness: {
+      low: 0,
+      high: 0,
+    },
   },
   lowlands: {
     blockType: BlockType.DRY_GRASS,
     threshold: 106,
+    randomness: {
+      low: 8,
+      high: 0,
+    },
   },
   highlands: {
     blockType: BlockType.GRASS,
     threshold: 125,
+    randomness: {
+      low: 0,
+      high: 15,
+    },
   },
   mountains: {
     blockType: BlockType.ROCK,
     threshold: 150,
+    randomness: {
+      low: 0,
+      high: 20,
+    },
   },
   mountains_top: {
     blockType: BlockType.SNOW,
     threshold: 185,
+    randomness: {
+      low: 25,
+      high: 0,
+    },
   },
 }

--- a/src/core/utils/terrain/world_settings.js
+++ b/src/core/utils/terrain/world_settings.js
@@ -1,6 +1,6 @@
 import { BlockType } from '@aresrpg/aresrpg-world'
 
-export const blocks_mapping = {
+export const blocks_colors = {
   [BlockType.NONE]: 0x000000,
   [BlockType.WATER]: 0x74ccf4,
   [BlockType.SAND]: 0xc2b280,


### PR DESCRIPTION
- adding settings to allow tweaking painting randomness implemented in world
- misc fixes for water and terrain level in LOD from former branch `fix/terrain-height` (could skip related PR #64  and use this one instead)