### PR TITLE
Feat/improve player controls

### DIFF
--- a/src/components/game-ui/game-interface.vue
+++ b/src/components/game-ui/game-interface.vue
@@ -34,6 +34,9 @@ import gameChat from './game-chat.vue';
     flex-flow row nowrap
     justify-content center
     align-items center
+    pointer-events none
+    > *
+      pointer-events all
     .server
       font-size .8em
       color #EEEEEE
@@ -42,4 +45,7 @@ import gameChat from './game-chat.vue';
     right 0
     bottom 0
     display grid
+    pointer-events none
+    > *
+      pointer-events all
 </style>

--- a/src/core/game/game.js
+++ b/src/core/game/game.js
@@ -132,6 +132,8 @@ export const INITIAL_STATE = {
   },
 
   inputs: {
+    mouseLeft: false,
+    mouseRight: false,
     forward: false,
     backward: false,
     left: false,

--- a/src/core/game/game.js
+++ b/src/core/game/game.js
@@ -132,8 +132,8 @@ export const INITIAL_STATE = {
   },
 
   inputs: {
-    mouseLeft: false,
-    mouseRight: false,
+    mouse_left: false,
+    mouse_right: false,
     forward: false,
     backward: false,
     left: false,

--- a/src/core/game/pool.js
+++ b/src/core/game/pool.js
@@ -288,6 +288,7 @@ export default function create_pools(scene) {
           height,
           radius,
           mixer,
+          object3d: origin,
           jump_time: 0,
           audio: null,
           action: null,

--- a/src/core/modules/player_inputs.js
+++ b/src/core/modules/player_inputs.js
@@ -17,6 +17,20 @@ export default function () {
           ...state,
           inputs,
         }
+      } else if (type === 'action/mousedown' || type === 'action/mouseup') {
+        const button = payload
+        const { inputs } = state
+        const enabled = type === 'action/mousedown'
+        if (button === 0) {
+          inputs.mouseLeft = enabled
+        } else if (button === 2) {
+          inputs.mouseRight = enabled
+        }
+
+        return {
+          ...state,
+          inputs,
+        }
       }
       return state
     },
@@ -28,6 +42,14 @@ export default function () {
       // @ts-ignore
       aiter(on(window, 'keyup', { signal })).forEach(([{ code }]) =>
         dispatch('action/keyup', code),
+      )
+      // @ts-ignore
+      aiter(on(window, 'mouseup', { signal })).forEach(([{ button }]) =>
+        dispatch('action/mouseup', button),
+      )
+      // @ts-ignore
+      aiter(on(window, 'mousedown', { signal })).forEach(([{ button }]) =>
+        dispatch('action/mousedown', button),
       )
     },
   }

--- a/src/core/modules/player_inputs.js
+++ b/src/core/modules/player_inputs.js
@@ -31,6 +31,21 @@ export default function () {
           ...state,
           inputs,
         }
+      } else if (type === 'action/window_focus') {
+        const lost_focus = !payload
+        if (lost_focus) {
+          const { inputs } = state
+          inputs.mouseLeft = false
+          inputs.mouseRight = false
+          inputs.forward = false
+          inputs.backward = false
+          inputs.left = false
+          inputs.right = false
+          return {
+            ...state,
+            inputs,
+          }
+        }
       }
       return state
     },
@@ -50,6 +65,11 @@ export default function () {
       // @ts-ignore
       aiter(on(window, 'mousedown', { signal })).forEach(([{ button }]) =>
         dispatch('action/mousedown', button),
+      )
+
+      // @ts-ignore
+      aiter(on(window, 'blur', { signal })).forEach(() =>
+        dispatch('action/window_focus', false),
       )
     },
   }

--- a/src/core/modules/player_inputs.js
+++ b/src/core/modules/player_inputs.js
@@ -22,9 +22,9 @@ export default function () {
         const { inputs } = state
         const enabled = type === 'action/mousedown'
         if (button === 0) {
-          inputs.mouseLeft = enabled
+          inputs.mouse_left = enabled
         } else if (button === 2) {
-          inputs.mouseRight = enabled
+          inputs.mouse_right = enabled
         }
 
         return {
@@ -35,8 +35,8 @@ export default function () {
         const lost_focus = !payload
         if (lost_focus) {
           const { inputs } = state
-          inputs.mouseLeft = false
-          inputs.mouseRight = false
+          inputs.mouse_left = false
+          inputs.mouse_right = false
           inputs.forward = false
           inputs.backward = false
           inputs.left = false

--- a/src/core/modules/player_movement.js
+++ b/src/core/modules/player_movement.js
@@ -87,7 +87,8 @@ export default function () {
 
       const movement = new Vector3()
 
-      if (inputs.forward) movement.add(camera_forward)
+      if (inputs.forward || (inputs.mouseLeft && inputs.mouseRight))
+        movement.add(camera_forward)
       if (inputs.backward) movement.sub(camera_forward)
       if (inputs.right) movement.add(camera_right)
       if (inputs.left) movement.sub(camera_right)
@@ -186,8 +187,7 @@ export default function () {
         player.move(dummy.position)
       }
 
-      const is_moving_horizontally =
-        inputs.forward || inputs.backward || inputs.right || inputs.left
+      const is_moving_horizontally = movement.x !== 0 || movement.z !== 0
 
       if (inputs.dance && !is_dancing && Date.now() - last_dance > 1000) {
         is_dancing = true

--- a/src/core/modules/player_movement.js
+++ b/src/core/modules/player_movement.js
@@ -87,7 +87,7 @@ export default function () {
 
       const movement = new Vector3()
 
-      if (inputs.forward || (inputs.mouseLeft && inputs.mouseRight))
+      if (inputs.forward || (inputs.mouse_left && inputs.mouse_right))
         movement.add(camera_forward)
       if (inputs.backward) movement.sub(camera_forward)
       if (inputs.right) movement.add(camera_right)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -97,6 +97,8 @@ declare namespace Type {
     'action/target_fps': number
     'action/keydown': string
     'action/keyup': string
+    'action/mousedown': number
+    'action/mouseup': number
     'action/select_character': string
     'action/view_distance': number
     'action/free_camera': boolean

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -32,6 +32,7 @@ declare namespace Type {
     title: import('troika-three-text').Text
     position: import('three').Vector3
     target_position: Position | null
+    object3d?: import('three').Object3D
     set_low_priority?: (skip: boolean) => void
     apply_state: (entity: Partial<ThreeEntity>) => void
     move: (position: Position) => void

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -99,6 +99,7 @@ declare namespace Type {
     'action/keyup': string
     'action/mousedown': number
     'action/mouseup': number
+    'action/window_focus': boolean
     'action/select_character': string
     'action/view_distance': number
     'action/free_camera': boolean


### PR DESCRIPTION
This PR improves the player controls:
- pressing simultaneously left and right mouse button makes the player go forward
- ~~added distinction between "turn left/right" and "strafe left/right"~~
- ~~moving the player while pressing right mouse button makes the player follow the camera position~~
- ~~moving the player while pressing left mouse button fixes the camera independently from the player movement~~
- ~~moving the player while not pressing left/right mouse button makes the camera follow the player movement~~
- add support for first-person view

Also, this PR fixes two bugs:
- losing window focus while moving the player made the player run indefinitely without user input, because we did not register the `window.keyup` event
- css: top/bottom panels prevented mouse interaction which was confusing