### PR TITLE
fix: make free camera more usable

### DIFF
--- a/src/core/modules/game_camera.js
+++ b/src/core/modules/game_camera.js
@@ -135,7 +135,7 @@ export default function () {
               renderer.domElement.removeEventListener('wheel', on_mouse_wheel)
               set_camera_padding(0, 0, 0, 0)
               // @ts-ignore
-              camera_controls.mouseButtons.right = CameraControls.ACTION.OFFSET
+              camera_controls.mouseButtons.right = CameraControls.ACTION.TRUCK
               // @ts-ignore
               camera_controls.mouseButtons.wheel = CameraControls.ACTION.DOLLY
             } else {


### PR DESCRIPTION
This PR fixes camera bugs related to the "free camera" mode:
- when in "free camera" mode, make right click behave as you would expect
- when toggling off "free camera", recenter the camera on the player