### PR TITLE
Feat/customizable colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3119,6 +3119,18 @@
         "url": "https://github.com/sponsors/kazupon"
       }
     },
+    "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/shared": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.5.tgz",
+      "integrity": "sha512-bmsP4L2HqBF6i6uaMqJMcFBONVjKt+siGluRq4Ca4C0q7W2eMaVZr8iCgF9dKbcVXutftkC7D6z2SaSMmLiDyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/@intlify/vue-i18n-extensions/node_modules/vue-i18n": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@aresrpg/aresrpg-dapp",
       "version": "6.1.4",
       "dependencies": {
-        "@aresrpg/aresrpg-engine": "2.6.5",
+        "@aresrpg/aresrpg-engine": "2.6.6",
         "@aresrpg/aresrpg-protocol": "5.1.7",
         "@aresrpg/aresrpg-sdk": "5.0.23",
         "@aresrpg/aresrpg-world": "1.7.2",
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@aresrpg/aresrpg-engine": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@aresrpg/aresrpg-engine/-/aresrpg-engine-2.6.5.tgz",
-      "integrity": "sha512-dlFceBYxIWF1bbgcWp6xllxouFrUbuJdCDXJ9aDV4p47NWStj/LkZbJkgGQzh2xEDKS6csxyhqjE0RMMOcqEvA==",
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/@aresrpg/aresrpg-engine/-/aresrpg-engine-2.6.6.tgz",
+      "integrity": "sha512-ixPGR3/4oEi0yIY+DdW83TC6/1bOmzQveE6uu5CopEYR9vjMe6E3E7fO4aqam4KyIT5HhoFiVpjZdLkqDtaZFA==",
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2960,6 +2960,18 @@
         "url": "https://github.com/sponsors/kazupon"
       }
     },
+    "node_modules/@intlify/core-base/node_modules/@intlify/shared": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.0.0.tgz",
+      "integrity": "sha512-MLKIyFz37qYF1G5UQZMwGoJyp8DD3rtcXDplRHZdSOmbfOYbD4g9kJZ6qCsm1Ru3vee6CTnJcbO4LV1JeIDGbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/@intlify/message-compiler": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.0.0.tgz",
@@ -2969,6 +2981,18 @@
         "@intlify/shared": "11.0.0",
         "source-map-js": "^1.0.2"
       },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler/node_modules/@intlify/shared": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.0.0.tgz",
+      "integrity": "sha512-MLKIyFz37qYF1G5UQZMwGoJyp8DD3rtcXDplRHZdSOmbfOYbD4g9kJZ6qCsm1Ru3vee6CTnJcbO4LV1JeIDGbA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -3088,18 +3112,6 @@
         "@intlify/shared": "10.0.5",
         "source-map-js": "^1.0.2"
       },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/shared": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.5.tgz",
-      "integrity": "sha512-bmsP4L2HqBF6i6uaMqJMcFBONVjKt+siGluRq4Ca4C0q7W2eMaVZr8iCgF9dKbcVXutftkC7D6z2SaSMmLiDyA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -4400,6 +4412,23 @@
         "vscode-uri": "^3.0.8"
       }
     },
+    "node_modules/@volar/typescript/node_modules/@volar/language-core": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
+      "integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.11"
+      }
+    },
+    "node_modules/@volar/typescript/node_modules/@volar/source-map": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
+      "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vscode/l10n": {
       "version": "0.0.18",
       "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
@@ -4499,6 +4528,23 @@
         }
       }
     },
+    "node_modules/@vue/language-core/node_modules/@volar/language-core": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
+      "integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.11"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/@volar/source-map": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
+      "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vue/language-plugin-pug": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@vue/language-plugin-pug/-/language-plugin-pug-2.2.0.tgz",
@@ -4509,6 +4555,13 @@
         "@volar/source-map": "~2.4.11",
         "volar-service-pug": "0.0.62"
       }
+    },
+    "node_modules/@vue/language-plugin-pug/node_modules/@volar/source-map": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
+      "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.13",
@@ -4716,9 +4769,9 @@
       "license": "MIT"
     },
     "node_modules/alien-signals": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.9.tgz",
-      "integrity": "sha512-piRGlMgQ65uRiY06mGU7I432AwPwAGf64TK1RXtM1Px4pPfLMTGI9TmsHTfioW1GukZRsNzkVQ/uHjhhd231Ow==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.10.tgz",
+      "integrity": "sha512-7S60rz/mMjz0Djq1VI9rd4bGqKNgxTUGE6k7kwrRO6tF95qt1S3ohz1qaQisvUsfbGh7yXnm6DPRrOhOl1ho1A==",
       "dev": true,
       "license": "MIT"
     },
@@ -12200,6 +12253,18 @@
       },
       "peerDependencies": {
         "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vue-i18n/node_modules/@intlify/shared": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.0.0.tgz",
+      "integrity": "sha512-MLKIyFz37qYF1G5UQZMwGoJyp8DD3rtcXDplRHZdSOmbfOYbD4g9kJZ6qCsm1Ru3vee6CTnJcbO4LV1JeIDGbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/vue-next-breakpoints": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "publish:mainnet": "git tag mainnet-$(node -p -e \"require('./package.json').version\") && git push origin mainnet-$(node -p -e \"require('./package.json').version\")"
   },
   "dependencies": {
-    "@aresrpg/aresrpg-engine": "2.6.5",
+    "@aresrpg/aresrpg-engine": "2.6.6",
     "@aresrpg/aresrpg-protocol": "5.1.7",
     "@aresrpg/aresrpg-sdk": "5.0.23",
     "@aresrpg/aresrpg-world": "1.7.2",

--- a/src/components/game-ui/character-canvas-display.vue
+++ b/src/components/game-ui/character-canvas-display.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, onUnmounted, ref, watch, watchEffect } from 'vue';
+import { inject, onMounted, onUnmounted, ref, watch, watchEffect } from 'vue';
 import {
   Scene,
   PerspectiveCamera,
@@ -20,7 +20,11 @@ const canvas = ref(null);
 
 const running = ref(false);
 
-const props = defineProps(['type', 'color1', 'color2', 'color3']);
+const props = defineProps(['type']);
+
+const color1 = inject('create_character_color1');
+const color2 = inject('create_character_color2');
+const color3 = inject('create_character_color3');
 
 let senshi = null;
 let yajin = null;
@@ -98,17 +102,25 @@ async function display_classe(type) {
 }
 
 watchEffect(() => {
-  if (props.color1) {
-    senshi?.custom_colors.set_color(props.color1);
-    yajin?.custom_colors.set_color(props.color1);
+  if (color1.value) {
+    const color = new Color(color1.value);
+    senshi?.custom_colors.set_color1(color);
+    yajin?.custom_colors.set_color1(color);
   }
-  if (props.color2) {
-    senshi?.custom_colors.set_color2(props.color2);
-    yajin?.custom_colors.set_color2(props.color2);
+  if (color2.value) {
+    const color = new Color(color2.value);
+    senshi?.custom_colors.set_color2(color);
+    yajin?.custom_colors.set_color2(color);
   }
-  if (props.color3) {
-    senshi?.custom_colors.set_color3(props.color3);
-    yajin?.custom_colors.set_color3(props.color3);
+  if (color3.value) {
+    const color = new Color(color3.value);
+    senshi?.custom_colors.set_color3(color);
+    yajin?.custom_colors.set_color3(color);
+  }
+
+  if (renderer) {
+    senshi?.custom_colors.texture.update(renderer);
+    yajin?.custom_colors.texture.update(renderer);
   }
 });
 

--- a/src/components/game-ui/character-canvas-display.vue
+++ b/src/components/game-ui/character-canvas-display.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, onUnmounted, ref, watch } from 'vue';
+import { onMounted, onUnmounted, ref, watch, watchEffect } from 'vue';
 import {
   Scene,
   PerspectiveCamera,
@@ -20,7 +20,7 @@ const canvas = ref(null);
 
 const running = ref(false);
 
-const props = defineProps(['type']);
+const props = defineProps(['type', 'color1', 'color2', 'color3']);
 
 let senshi = null;
 let yajin = null;
@@ -96,6 +96,21 @@ async function display_classe(type) {
       break;
   }
 }
+
+watchEffect(() => {
+  if (props.color1) {
+    senshi?.custom_colors.set_color(props.color1);
+    yajin?.custom_colors.set_color(props.color1);
+  }
+  if (props.color2) {
+    senshi?.custom_colors.set_color2(props.color2);
+    yajin?.custom_colors.set_color2(props.color2);
+  }
+  if (props.color3) {
+    senshi?.custom_colors.set_color3(props.color3);
+    yajin?.custom_colors.set_color3(props.color3);
+  }
+});
 
 watch(
   props,

--- a/src/components/game-ui/character-create.vue
+++ b/src/components/game-ui/character-create.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject, ref, watch, computed } from 'vue';
+import { inject, ref, watch, computed, provide } from 'vue';
 import Spells from '@aresrpg/aresrpg-sdk/spells';
 import { useI18n } from 'vue-i18n';
 
@@ -26,6 +26,10 @@ const { t } = useI18n();
 const color1 = ref('#FFFFFF');
 const color2 = ref('#FF9999');
 const color3 = ref('#111FFF');
+
+provide('create_character_color1', color1);
+provide('create_character_color2', color2);
+provide('create_character_color3', color3);
 
 const characters = [
   {
@@ -205,7 +209,7 @@ vs-dialog(v-model="new_character_dialog" full-screen)
       )
     .desc {{ selected_class_data.desc }}
     .perso
-      characterCanvasDisplay(:type="selected_class_type" :color1="color1" :color2="color2" :color3="color3")
+      characterCanvasDisplay(:type="selected_class_type")
     .right
       .spells
         SpellDisplay(:spells="selected_class_data.spells")

--- a/src/components/game-ui/character-create.vue
+++ b/src/components/game-ui/character-create.vue
@@ -205,7 +205,7 @@ vs-dialog(v-model="new_character_dialog" full-screen)
       )
     .desc {{ selected_class_data.desc }}
     .perso
-      characterCanvasDisplay(:type="selected_class_type")
+      characterCanvasDisplay(:type="selected_class_type" :color1="color1" :color2="color2" :color3="color3")
     .right
       .spells
         SpellDisplay(:spells="selected_class_data.spells")

--- a/src/core/game/entities.js
+++ b/src/core/game/entities.js
@@ -43,9 +43,11 @@ function fade_to_animation(from, to, duration = 0.3) {
 // ]
 
 function create_customizable_textures(
-  /** @type ReadonlyArray<Texture> */ textures,
+  /** @type ReadonlyArray<Texture> */
+  textures,
 ) {
-  const /** @type Map<string, Texture> */ base_textures = new Map()
+  /** @type Map<string, Texture> */
+  const base_textures = new Map()
   for (const texture of textures) {
     const match = texture.name.match(/(.+)_base$/)
     if (match && match[1]) {
@@ -58,10 +60,11 @@ function create_customizable_textures(
 
   const MAX_CUSTOMIZABLE_TEXTURES_COUNT = 3
 
-  const /** @type Map<string, CustomizableTexture> */ customizable_textures =
-      new Map()
+  /** @type Map<string, CustomizableTexture> */
+  const customizable_textures = new Map()
   for (const [base_texture_name, base_texture] of base_textures.entries()) {
-    const /** @type Map<string, Texture> */ additional_textures = new Map()
+    /** @type Map<string, Texture> */
+    const additional_textures = new Map()
     for (let i = 1; i <= MAX_CUSTOMIZABLE_TEXTURES_COUNT; i++) {
       const layer_texture = textures.find(
         tex => tex.name === `${base_texture_name}_color${i}`,
@@ -86,9 +89,8 @@ function create_custom_colors_api(
   /** @type Object3D */ model,
   /** @type ReadonlyArray<Texture> */ textures,
 ) {
-  let custom_colors = null
-  const /** @type Map<string, CustomizableTexture> */ customizable_textures =
-      create_customizable_textures(textures)
+  /** @type Map<string, CustomizableTexture> */
+  const customizable_textures = create_customizable_textures(textures)
   if (customizable_textures.size > 0) {
     // attach the customizable textures on the model
     model.traverse((/** @type any */ child) => {
@@ -120,32 +122,32 @@ function create_custom_colors_api(
       }
     }
 
-    custom_colors = {
+    return {
       texture: customizable_texture_diffuse,
-      set color1(value) {
+      set_color1(value) {
         customizable_texture_diffuse.setLayerColor('color1', value)
       },
-      get color1() {
+      get_color1() {
         return customizable_texture_diffuse.getLayerColor('color1')
       },
 
-      set color2(value) {
+      set_color2(value) {
         customizable_texture_diffuse.setLayerColor('color2', value)
       },
-      get color2() {
+      get_color2() {
         return customizable_texture_diffuse.getLayerColor('color2')
       },
 
-      set color3(value) {
+      set_color3(value) {
         customizable_texture_diffuse.setLayerColor('color3', value)
       },
-      get color3() {
+      get_color3() {
         return customizable_texture_diffuse.getLayerColor('color3')
       },
     }
   }
 
-  return custom_colors
+  return null
 }
 
 function entity_spawner(
@@ -252,10 +254,9 @@ function entity_spawner(
         title.dispose()
         dispose(origin)
 
-        // TODO: uncomment once the engine is upgraded
-        // if (custom_colors) {
-        //   custom_colors.texture.dispose()
-        // }
+        if (custom_colors) {
+          custom_colors.texture.dispose()
+        }
       },
       animate(name) {
         // allow to skip some animation frames when the entity is far away

--- a/src/core/game/entities.js
+++ b/src/core/game/entities.js
@@ -152,10 +152,6 @@ function entity_spawner(
             ]),
           })
           customizable_textures.set(textureBasename, customizable_texture)
-          // below lines for debugging
-          // window.setColor0 = colorCode => customizable_texture.setLayerColor("basecolour", new Color(colorCode))
-          // window.setColor1 = colorCode => customizable_texture.setLayerColor("accent1", new Color(colorCode))
-          // window.setColor2 = colorCode => customizable_texture.setLayerColor("accent2", new Color(colorCode))
         }
       }
 
@@ -175,6 +171,34 @@ function entity_spawner(
       })
     }
 
+    let custom_colors = null
+    if (customizable_textures.has("x")) {
+      const customizable_texture = customizable_textures.get("x");
+      custom_colors = {
+        texture: customizable_texture,
+        set color1(value) {
+          customizable_texture.setLayerColor("basecolour", value)
+        },
+        get color1() {
+          return customizable_texture.getLayerColor("basecolour")
+        },
+
+        set color2(value) {
+          customizable_texture.setLayerColor("accent1", value)
+        },
+        get color2() {
+          return customizable_texture.getLayerColor("accent1")
+        },
+
+        set color3(value) {
+          customizable_texture.setLayerColor("accent2", value)
+        },
+        get color3() {
+          return customizable_texture.getLayerColor("accent2")
+        },
+      }
+    }
+  
     return {
       id,
       floating_title: title,
@@ -182,7 +206,6 @@ function entity_spawner(
       radius,
       mixer,
       object3d: origin,
-      customizable_textures,
       jump_time: 0,
       audio: null,
       skin,
@@ -227,6 +250,7 @@ function entity_spawner(
       position: origin.position,
       target_position: null,
       set_variant,
+      custom_colors,
       equip_hat,
       async set_hair() {
         if (id === 'default') return

--- a/src/core/modules/player_characters.js
+++ b/src/core/modules/player_characters.js
@@ -1,4 +1,5 @@
 import { Color } from 'three'
+
 import { ENTITIES } from '../game/entities.js'
 import { context, current_three_character } from '../game/game.js'
 import { experience_to_level } from '../utils/game/experience.js'
@@ -16,7 +17,7 @@ export default function () {
 
         if (player.custom_colors) {
           if (player.custom_colors.texture.needsUpdate) {
-            player.custom_colors.texture.update(renderer);
+            player.custom_colors.texture.update(renderer)
           }
         }
       }

--- a/src/core/modules/player_characters.js
+++ b/src/core/modules/player_characters.js
@@ -1,3 +1,4 @@
+import { Color } from 'three'
 import { ENTITIES } from '../game/entities.js'
 import { context, current_three_character } from '../game/game.js'
 import { experience_to_level } from '../utils/game/experience.js'
@@ -13,11 +14,9 @@ export default function () {
           player.mixer.update(delta)
         }
 
-        if (player.customizable_textures) {
-          for (const customizable_texture of player.customizable_textures.values()) {
-            if (customizable_texture.needsUpdate) {
-              customizable_texture.update(renderer)
-            }
+        if (player.custom_colors) {
+          if (player.custom_colors.texture.needsUpdate) {
+            player.custom_colors.texture.update(renderer);
           }
         }
       }

--- a/src/core/modules/player_characters.js
+++ b/src/core/modules/player_characters.js
@@ -6,9 +6,21 @@ import { state_iterator } from '../utils/iterator.js'
 /** @type {Type.Module} */
 export default function () {
   return {
-    tick(state, __, delta) {
+    tick(state, { renderer }, delta) {
       const player = current_three_character(state)
-      if (player?.mixer) player.mixer.update(delta)
+      if (player) {
+        if (player.mixer) {
+          player.mixer.update(delta)
+        }
+
+        if (player.customizable_textures) {
+          for (const customizable_texture of player.customizable_textures.values()) {
+            if (customizable_texture.needsUpdate) {
+              customizable_texture.update(renderer)
+            }
+          }
+        }
+      }
     },
     reduce(state, { type, payload }) {
       if (type === 'action/select_character')

--- a/src/core/utils/three/load_model.js
+++ b/src/core/utils/three/load_model.js
@@ -26,8 +26,11 @@ export async function load(
   path,
   { env_map_intensity = 0.5, mesh_name = 'Model' } = {},
 ) {
+  const loaded = await GLTF_LOADER.loadAsync(path)
   // @ts-ignore
-  const { scene, animations, functions } = await GLTF_LOADER.loadAsync(path)
+  const textures = await Promise.all(Object.values(loaded.parser.textureCache))
+  // @ts-ignore
+  const { scene, animations, functions } = loaded
 
   scene.traverse(child => {
     // @ts-ignore
@@ -49,6 +52,7 @@ export async function load(
 
     return {
       model: cloned,
+      textures,
       skinned_mesh: cloned.getObjectByName(mesh_name),
       async set_variant(variant) {
         await functions.selectVariant(cloned, variant)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -55,11 +55,11 @@ declare namespace Type {
     mob_group_id?: string
     current_fight_id?: string
     custom_colors: null | {
-      texture: import('@aresrpg/aresrpg-engine').CustomizableTexture,
-      color1: import('three').Color,
-      color2: import('three').Color,
-      color3: import('three').Color,
-    },
+      texture: import('@aresrpg/aresrpg-engine').CustomizableTexture
+      color1: import('three').Color
+      color2: import('three').Color
+      color3: import('three').Color
+    }
   }
 
   type MobGroup = Omit<

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -54,6 +54,10 @@ declare namespace Type {
     set_hair(): Promise<void>
     mob_group_id?: string
     current_fight_id?: string
+    customizable_textures: Map<
+      string,
+      import('@aresrpg/aresrpg-engine').CustomizableTexture
+    > | null
   }
 
   type MobGroup = Omit<

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -56,9 +56,12 @@ declare namespace Type {
     current_fight_id?: string
     custom_colors: null | {
       texture: import('@aresrpg/aresrpg-engine').CustomizableTexture
-      color1: import('three').Color
-      color2: import('three').Color
-      color3: import('three').Color
+      get_color1(): import('three').Color
+      get_color2(): import('three').Color
+      get_color3(): import('three').Color
+      set_color1(color: import('three').Color): void
+      set_color2(color: import('three').Color): void
+      set_color3(color: import('three').Color): void
     }
   }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -54,10 +54,12 @@ declare namespace Type {
     set_hair(): Promise<void>
     mob_group_id?: string
     current_fight_id?: string
-    customizable_textures: Map<
-      string,
-      import('@aresrpg/aresrpg-engine').CustomizableTexture
-    > | null
+    custom_colors: null | {
+      texture: import('@aresrpg/aresrpg-engine').CustomizableTexture,
+      color1: import('three').Color,
+      color2: import('three').Color,
+      color3: import('three').Color,
+    },
   }
 
   type MobGroup = Omit<


### PR DESCRIPTION
This PR adds support for customizable colors on models that support it, by adding a new API
```ts
ThreeEntity.custom_colors: null | {
      color1: THREE.Color
      color2: THREE.Color
      color3: THREE.Color
    }
```

For a model to support it, it should have textures:
- `diffuse_base`
- `diffuse_color1`
- `diffuse_color2`
- `diffuse_color3`

Then on this model, the `diffuse_base` is replaced by a texture computed as follows:
on a transparent canvas, I first draw the original unmodified `diffuse_base`. Then on top of it, I draw `diffuse_color1` colored by color1, then `diffuse_color2` colored by color2 etc.

More generally, this PR prepares code to support any customizable texture based on the naming scheme `XXX_base`, `XXX_color1`, `XXX_color2` etc.