### PR TITLE
perf: try to query less the world for LOD/minimap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@aresrpg/aresrpg-dapp",
       "version": "6.1.12",
       "dependencies": {
-        "@aresrpg/aresrpg-engine": "^2.7.8",
+        "@aresrpg/aresrpg-engine": "^2.7.9",
         "@aresrpg/aresrpg-protocol": "5.4.0",
         "@aresrpg/aresrpg-sdk": "5.2.21",
         "@aresrpg/aresrpg-world": "2.0.4",
@@ -188,14 +188,14 @@
       }
     },
     "node_modules/@aresrpg/aresrpg-engine": {
-      "version": "2.7.8",
-      "resolved": "https://registry.npmjs.org/@aresrpg/aresrpg-engine/-/aresrpg-engine-2.7.8.tgz",
-      "integrity": "sha512-ziHoNBSVPGwts+DtCette2gJRn4ti07EdDXbcNw4DFKW7HHkjjmsXvjDP7DxXRMwdWfFA0D8ltYLw8rcdCbOBQ==",
+      "version": "2.7.9",
+      "resolved": "https://registry.npmjs.org/@aresrpg/aresrpg-engine/-/aresrpg-engine-2.7.9.tgz",
+      "integrity": "sha512-SD4cQhxTJk3BAzrA3q09mvpoC9k1mu6mBPJdME5f5rK7JumMKfUPJgJGLb1KQ5BdWKgYzutNvd2msn2U9eoJ0Q==",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "three": ">=0.173.0"
+        "three": ">=0.174.0"
       }
     },
     "node_modules/@aresrpg/aresrpg-protocol": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "publish:mainnet": "git tag mainnet-$(node -p -e \"require('./package.json').version\") && git push origin mainnet-$(node -p -e \"require('./package.json').version\")"
   },
   "dependencies": {
-    "@aresrpg/aresrpg-engine": "^2.7.8",
+    "@aresrpg/aresrpg-engine": "^2.7.9",
     "@aresrpg/aresrpg-protocol": "5.4.0",
     "@aresrpg/aresrpg-sdk": "5.2.21",
     "@aresrpg/aresrpg-world": "2.0.4",

--- a/src/core/game/voxel_engine.js
+++ b/src/core/game/voxel_engine.js
@@ -107,6 +107,10 @@ export function create_voxel_engine() {
 
   const heightmap_atlas = new HeightmapAtlas({
     heightmap: map,
+    heightmapQueries: {
+      interval: 200,
+      batching: 2,
+    },
     materialsStore: voxels_materials_store,
     texelSizeInWorld: 2,
     leafTileSizeInWorld: voxelmap_viewer.chunkSize.xz,
@@ -131,6 +135,7 @@ export function create_voxel_engine() {
   const minimap = new Minimap({
     heightmapAtlas: heightmap_atlas,
     waterData: water_data,
+    heightmapAtlasDownscalingFactor: 3,
     meshPrecision: 64,
     minViewDistance: 100,
     maxViewDistance: 750,


### PR DESCRIPTION
Update engine to get perf improvements:
- the minimap makes 4 times less queries to the world
- the LOD and minimap queries to the world are now batched, to reduce communication overhead