### PR TITLE
Feat/mainnet version

### DIFF
--- a/src/assets/translations/en.yaml
+++ b/src/assets/translations/en.yaml
@@ -14,6 +14,7 @@ SERVER_FEATURE_NOT_AVAILABLE: This feature is not available yet
 
 APP_MAINTENANCE: AresRPG is currently under maintenance, please come back later.
 APP_LOGIN_AGAIN: Please login again
+APP_WORLD_JOIN: Join the world
 APP_WALLET_NOT_FOUND: Wallet not found
 APP_OUTDATED: The app is outdated and can't use this feature. Please update the app.
 APP_WAIT_A_MINUTE: Please wait before trying again

--- a/src/assets/translations/fr.yaml
+++ b/src/assets/translations/fr.yaml
@@ -14,6 +14,7 @@ SERVER_FEATURE_NOT_AVAILABLE: Cette fonctionnalité n'est pas encore disponible
 
 APP_MAINTENANCE: AresRPG est actuellement en maintenance, veuillez revenir plus tard
 APP_LOGIN_AGAIN: Veuillez vous reconnecter
+APP_WORLD_JOIN: Rejoindre le monde
 APP_WALLET_NOT_FOUND: Portefeuille non trouvé
 APP_OUTDATED: L'application est obsolète et ne peut pas utiliser cette fonctionnalité. Veuillez mettre à jour AresRPG.
 APP_WAIT_A_MINUTE: Veuillez attendre avant de réessayer

--- a/src/assets/translations/jp.yaml
+++ b/src/assets/translations/jp.yaml
@@ -14,6 +14,7 @@ SERVER_FEATURE_NOT_AVAILABLE: この機能はまだ利用できません
 
 APP_MAINTENANCE: AresRPGは現在メンテナンス中です。後で戻ってきてください。
 APP_LOGIN_AGAIN: もう一度ログインしてください。
+APP_WORLD_JOIN: 世界に参加
 APP_WALLET_NOT_FOUND: ウォレットが見つかりません。
 APP_OUTDATED: アプリが古くなっており、この機能を使用できません。アプ"リを更新してください。
 APP_WAIT_A_MINUTE: もう一度試す前に少しお待ちください。

--- a/src/components/cards/user-character.vue
+++ b/src/components/cards/user-character.vue
@@ -11,7 +11,12 @@
     .title id:
     a.value.id(:href="character_explorer_link" target="_blank") {{ props.character.id.slice(0, 24) }}...
   .actions
+    div(v-if="VITE_DEMO_MODE")
     vs-button(
+        @click="play"
+      ) Entrer en jeu
+    vs-button(
+      v-if="!VITE_DEMO_MODE"
       type="transparent"
       size="small"
       color="#EF5350"
@@ -37,7 +42,10 @@ import characterCanvasDisplay from '../game-ui/character-canvas-display.vue';
 import { experience_to_level } from '../../core/utils/game/experience.js';
 import { sui_delete_character } from '../../core/sui/client.js';
 import toast from '../../toast.js';
-import { NETWORK } from '../../env.js';
+import { NETWORK, VITE_DEMO_MODE } from '../../env.js';
+import { useRouter } from 'vue-router';
+
+import { context } from '../../core/game/game.js';
 
 const { t } = useI18n();
 const props = defineProps(['character', 'locked']);
@@ -63,6 +71,12 @@ const send_dialog = ref(false);
 const send_to = ref('');
 const send_loading = ref(false);
 
+const router = useRouter();
+
+function play() {
+  // context.dispatch('action/select_character', character.id);
+  router.push('/world')  
+}
 async function delete_character() {
   const { update, remove } = toast.tx(
     t('APP_USER_DELETING'),

--- a/src/components/cards/user-character.vue
+++ b/src/components/cards/user-character.vue
@@ -7,14 +7,15 @@
     .title classe:
     .value {{ props.character.classe.toUpperCase() }}
     i.bx(:class="genrer_icon")
-  .field
+  .field(v-if="!VITE_DEMO_MODE")
     .title id:
     a.value.id(:href="character_explorer_link" target="_blank") {{ props.character.id.slice(0, 24) }}...
-  .actions
-    div(v-if="VITE_DEMO_MODE")
+  .play_btn(v-if="VITE_DEMO_MODE")
     vs-button(
         @click="play"
-      ) Entrer en jeu
+        color="#E74C3C"
+      ) {{ t('APP_WORLD_JOIN') }}
+  .actions
     vs-button(
       v-if="!VITE_DEMO_MODE"
       type="transparent"
@@ -75,8 +76,9 @@ const router = useRouter();
 
 function play() {
   // context.dispatch('action/select_character', character.id);
-  router.push('/world')  
+  router.push('/world')
 }
+
 async function delete_character() {
   const { update, remove } = toast.tx(
     t('APP_USER_DELETING'),
@@ -173,6 +175,13 @@ function has_equipment(character) {
     display flex
     justify-content flex-end
     font-size .8em
+  
+  .play_btn
+    display flex
+    justify-content center
+    font-size .8em
+    padding 8px 0
+
 
   span.name
     text-transform capitalize

--- a/src/components/navigation/side-bar.vue
+++ b/src/components/navigation/side-bar.vue
@@ -17,7 +17,7 @@
     vs-sidebar-item(id="shop" @click="router.push('/shop')") {{ t('APP_SIDEBAR_SHOP') }}
       template(#icon)
         i.bx.bxs-store
-    vs-sidebar-item(id="workshop" @click="router.push('/workshop')") {{ t('APP_SIDEBAR_WORKSHOP') }}
+    vs-sidebar-item(v-if="!VITE_DEMO_MODE" id="workshop" @click="router.push('/workshop')") {{ t('APP_SIDEBAR_WORKSHOP') }}
       template(#icon)
         i.bx.bx-cut
     vs-sidebar-item(id="settings" @click="router.push('/settings')") {{ t('APP_SIDEBAR_SETTINGS') }}

--- a/src/components/navigation/side-bar.vue
+++ b/src/components/navigation/side-bar.vue
@@ -11,7 +11,7 @@
     vs-sidebar-item(id="characters" @click="router.push('/characters')") {{ t('APP_SIDEBAR_CHARACTERS') }}
       template(#icon)
         i.bx.bxs-user-account
-    vs-sidebar-item(v-if="is_world_visible" id="world" @click="router.push('/world')" ) {{ t('APP_SIDEBAR_WORLD') }}
+    vs-sidebar-item(v-if="is_world_visible && !VITE_DEMO_MODE" id="world" @click="router.push('/world')" ) {{ t('APP_SIDEBAR_WORLD') }}
       template(#icon)
         i.bx.bx-world
     vs-sidebar-item(id="shop" @click="router.push('/shop')") {{ t('APP_SIDEBAR_SHOP') }}
@@ -47,6 +47,7 @@ import { useI18n } from 'vue-i18n';
 import pkg from '../../../package.json';
 import serverInfo from '../cards/server-info.vue';
 import { context } from '../../core/game/game';
+import { VITE_DEMO_MODE } from '../../env.js';
 
 const lang_dialog = inject('lang_dialog');
 const { t } = useI18n();

--- a/src/core/modules/ui_fps.js
+++ b/src/core/modules/ui_fps.js
@@ -5,6 +5,7 @@ import { aiter } from 'iterator-helper'
 
 import { abortable, typed_on } from '../utils/iterator.js'
 import { get_spawned_entities_count } from '../utils/game/entities.js'
+import { VITE_DEMO_MODE } from '../../env.js'
 
 /** @type {Type.Module} */
 export default function () {
@@ -105,6 +106,7 @@ export default function () {
         })
 
       on_game_show(() => {
+        if (VITE_DEMO_MODE) return
         show_stats(show_fps)
       })
 

--- a/src/core/modules/ui_settings.js
+++ b/src/core/modules/ui_settings.js
@@ -10,6 +10,7 @@ import {
   current_three_character,
 } from '../game/game.js'
 import { get_nearest_floor_pos } from '../utils/terrain/world_utils.js'
+import { VITE_DEMO_MODE } from '../../env.js'
 
 import { create_board } from './game_fights.js'
 
@@ -20,6 +21,8 @@ export default function () {
   return {
     observe({ events, dispatch, signal, on_game_hide, on_game_show }) {
       const gui = new GUI()
+
+      if (VITE_DEMO_MODE) gui.destroy()
 
       gui.useLocalStorage = true
 

--- a/src/env.js
+++ b/src/env.js
@@ -3,7 +3,8 @@ const {
   VITE_SERVER_URL,
   VITE_ENOKI_KEY = 'enoki_public_ff89078fe8efa82d3f14732264813b91',
   VITE_NETWORK = 'testnet',
+  VITE_DEMO_MODE,
 } = import.meta.env
 
 export const NETWORK = VITE_NETWORK
-export { VITE_SUI_RPC, VITE_SERVER_URL, VITE_ENOKI_KEY }
+export { VITE_SUI_RPC, VITE_SERVER_URL, VITE_ENOKI_KEY, VITE_DEMO_MODE }

--- a/src/views/tab-characters.vue
+++ b/src/views/tab-characters.vue
@@ -34,7 +34,7 @@ sectionContainer(v-if="NETWORK === 'testnet'")
     .character-container
       div.nothing(v-if="characters[0]?.id === 'default'")
       UserCharacter(v-else v-for="character in characters" :key="character.id" :locked="true" :character="character")
-      .new(v-if="characters.length < 3" @click="new_character_dialog = true") {{ t('APP_CHARACTER_NEW') }}
+      .new(v-if="characters.length < 3 && !VITE_DEMO_MODE" @click="new_character_dialog = true") {{ t('APP_CHARACTER_NEW') }}
 
   // Create a new character
   CharacterCreateVue(@cancel="new_character_dialog = false")

--- a/src/views/tab-characters.vue
+++ b/src/views/tab-characters.vue
@@ -4,7 +4,7 @@ import { ref, provide, inject, defineAsyncComponent } from 'vue';
 
 import sectionHeader from '../components/misc/section-header.vue';
 import sectionContainer from '../components/misc/section-container.vue';
-import { NETWORK } from '../env.js';
+import { NETWORK, VITE_DEMO_MODE } from '../env.js';
 
 const UserCharacter = defineAsyncComponent(
   () => import('../components/cards/user-character.vue'),
@@ -23,13 +23,13 @@ provide('new_character_dialog', new_character_dialog);
 
 <template lang="pug">
 sectionContainer(v-if="NETWORK === 'testnet'")
-  vs-alert(type="relief" color="#0D47A1")
+  vs-alert(v-if="!VITE_DEMO_MODE" type="relief" color="#0D47A1")
     template(#title) {{ t('APP_WELCOME') }}
     .alert-content
       i18n-t(keypath="APP_TAB_CHARACTERS_EXPLANATION" tag="p")
         b.sui Sui
       .explanation2 {{ t('APP_TAB_CHARACTERS_EXPLANATION_ALT') }}
-  .space
+  .space(v-if="!VITE_DEMO_MODE")
   sectionHeader(:title="t('APP_CHARACTERS')" color="#00C853")
     .character-container
       div.nothing(v-if="characters[0]?.id === 'default'")


### PR DESCRIPTION
## 🧪 PR Draft – Demo Mode for Mainnet

This branch introduces a simplified **demo mode** for the mainnet, aiming to streamline the user experience and provide quick access to the game world.

### ✅ Changes
-  Skipped character creation
-  Added an **"Enter Game"** button directly below the character
-  Hidden **World** and **Workshop** buttons from the main menu
-  Removed `dat.gui`, `stats.js`, and other debug tools
-  General UI cleanup to reduce friction and distractions

### ⚙️ How to enable
Add the following line to your `.env` file:
```env
VITE_DEMO_MODE=true
```

### 🎯 Goal
Make it as easy and clean as possible for users to access and explore the world — perfect for demos and first-time discovery.
