### PR TITLE
Fix/server errors and offline handling

### DIFF
--- a/src/assets/translations/en.yaml
+++ b/src/assets/translations/en.yaml
@@ -123,6 +123,11 @@ APP_ITEM_FED: Your pet is very happy now!
 APP_ITEM_PET_FULL: Your pet is not hungry
 APP_ITEM_FEED_FAILED: Failed to feed your pet
 APP_ITEM_FEED_NO_FOOD: Your pet doesn't seem to find any food he likes in your inventory, so picky!
+APP_PLAYER_ITEM_NOT_FOUND: Item not found.
+APP_PLAYER_ITEM_NOT_HANDLED: This item cannot be used here.
+APP_INTERNAL_ERROR: An internal error occurred.
+APP_CHARACTERS_LIMIT: Character limit reached.
+APP_INVALID_TRANSACTION_TYPE: Invalid transaction type.
 APP_ITEM_DELETE: Destroy item
 APP_ITEM_USE: Use item
 APP_ITEM_DELETE_CONFIRM: Delete

--- a/src/assets/translations/fr.yaml
+++ b/src/assets/translations/fr.yaml
@@ -124,6 +124,11 @@ APP_ITEM_FED: Votre familier est très heureux maintenant !
 APP_ITEM_PET_FULL: Votre familier n'a pas faim
 APP_ITEM_FEED_FAILED: Echec de l'alimentation de votre familier
 APP_ITEM_FEED_NO_FOOD: Votre animal de compagnie ne semble pas trouver de nourriture qui lui plaise dans votre inventaire, il est si difficile !
+APP_PLAYER_ITEM_NOT_FOUND: Objet introuvable.
+APP_PLAYER_ITEM_NOT_HANDLED: Cet objet ne peut pas être utilisé ici.
+APP_INTERNAL_ERROR: Une erreur interne est survenue.
+APP_CHARACTERS_LIMIT: Limite de personnages atteinte.
+APP_INVALID_TRANSACTION_TYPE: Type de transaction invalide.
 APP_ITEM_DELETE: Détruire l'item
 APP_ITEM_USE: Utiliser
 APP_ITEM_DELETE_CONFIRM: Supprimer

--- a/src/assets/translations/jp.yaml
+++ b/src/assets/translations/jp.yaml
@@ -122,6 +122,11 @@ APP_ITEM_FED: あなたのペットはとても幸せです！
 APP_ITEM_PET_FULL: あなたのペットはお腹がいっぱいです
 APP_ITEM_FEED_FAILED: ペットの餌やりに失敗しました
 APP_ITEM_FEED_NO_FOOD: あなたのペットはインベントリに好きな食べ物がないようです！
+APP_PLAYER_ITEM_NOT_FOUND: アイテムが見つかりません。
+APP_PLAYER_ITEM_NOT_HANDLED: このアイテムはここで使用できません。
+APP_INTERNAL_ERROR: 内部エラーが発生しました。
+APP_CHARACTERS_LIMIT: キャラクターの上限に達しました。
+APP_INVALID_TRANSACTION_TYPE: 無効な取引タイプです。
 APP_ITEM_DELETE: アイテムを削除する
 APP_ITEM_USE: アイテムを使用する
 APP_ITEM_DELETE_CONFIRM: 削除

--- a/src/core/game/error_handler.js
+++ b/src/core/game/error_handler.js
@@ -19,6 +19,10 @@ export function notify_reconnected() {
 
 export async function handle_server_error(reason) {
   if (!reason) {
+    if (navigator.onLine) {
+      // Show reconnect toast
+      return false
+    }
     if (!server_down_toast)
       server_down_toast = toast.tx(t('WS_CONNECTING_TO_SERVER'))
     server_down_toast.update('loading', t('WS_CONNECTING_TO_SERVER'))

--- a/src/core/game/game.js
+++ b/src/core/game/game.js
@@ -501,6 +501,8 @@ function connect_ws() {
               })
             }, 1000)
           else if (context.get_state().sui.selected_address) {
+            connecting_toast.remove()
+            connecting_toast = null
             reconnect_toast = toast.tx(
               i18n.global.t('SERVER_CLICK_TO_CONNECT'),
               i18n.global.t('SERVER_NOT_CONNECTED'),

--- a/src/core/modules/player_error.js
+++ b/src/core/modules/player_error.js
@@ -11,10 +11,15 @@ export default function () {
           case 'MISSING_FOOD':
             return toast.error(translate('APP_ITEM_FEED_NO_FOOD'))
           case 'ITEM_NOT_FOUND':
+            return toast.error(translate('APP_PLAYER_ITEM_NOT_FOUND'))
           case 'ITEM_NOT_HANDLED':
+            return toast.error(translate('APP_PLAYER_ITEM_NOT_HANDLED'))
           case 'INTERNAL_ERROR':
+            return toast.error(translate('APP_INTERNAL_ERROR'))
           case 'CHARACTERS_LIMIT':
+            return toast.error(translate('APP_CHARACTERS_LIMIT'))
           case 'INVALID_TRANSACTION_TYPE':
+            return toast.error(translate('APP_INVALID_TRANSACTION_TYPE'))
           default:
             toast.error(translate('PLAYER_UNHANDLED_ERROR'), message)
         }

--- a/src/core/modules/sui_data.js
+++ b/src/core/modules/sui_data.js
@@ -500,15 +500,15 @@ export default function () {
         if (selected_address) {
           await context.connect_ws()
 
-          await_connection_success_toast?.remove()
-          await_connection_success_toast = toast.tx(t('SUI_WAITING_SIGNATURE'))
-
           const [result] = await Promise.race([
             // @ts-ignore
             once(events, 'packet/connectionAccepted'),
             // @ts-ignore
             once(events, 'SIGNATURE_NOT_VERIFIED'),
           ])
+
+          await_connection_success_toast?.remove()
+          await_connection_success_toast = toast.tx(t('SUI_WAITING_SIGNATURE'))
 
           if (!result?.address) {
             await_connection_success_toast?.remove()


### PR DESCRIPTION
# 🛠 Pull Request: Failure Packet Handling & Offline Connection Improvements

## Description  
This pull request focuses on improving how the app handles server-side error messages and offline scenarios. It enhances the user's first experience by preventing confusing states and providing better UI feedback when the server is unreachable or fails to respond properly.

---

## Summary of Changes

### ⚙️ Features & Improvements
- **Handle `packet/failure` messages** [#184]  
  → Display localized toasts for known failure types such as:
  - `ITEM_NOT_FOUND`
  - `ITEM_NOT_HANDLED`
  - `INTERNAL_ERROR`
  - `CHARACTERS_LIMIT`
  - `INVALID_TRANSACTION_TYPE`

- **Improve offline server handling** [#168]  
  → Skip signature phase when connection fails  
  → Display reconnect button even if no successful connection has occurred  
  → Prevent infinite “Connecting to the server” loop when offline

---

## 🧪 Behavior & UX

- If the server is offline at launch:
  - ❌ No "verifying signature"
  - ✅ Shows a clear error message and the "Reconnect" button
  - ❌ Avoids infinite retries or misleading status messages

- If a server responds with a failure packet:
  - ✅ A toast appears with a translated and meaningful error message

---

## 📌 Related Issues

- Closes #168 – App should better handle an offline server  
- Closes #184 – Handle failure packet messages
