### PR TITLE
Fix/underwater rendering

### DIFF
--- a/src/core/game/game.js
+++ b/src/core/game/game.js
@@ -116,7 +116,7 @@ LOADING_MANAGER.onLoad = () => {
 /** @typedef {(state: State, action: Type.Action) => State} Reducer */
 /** @typedef {(context: Context) => void} Observer */
 /** @typedef {(state: State, context: Context, delta: number) => void} Ticker */
-/** @typedef {(context: Context) => void} PostRenderCallback */
+/** @typedef {(state: State, context: Context) => void} PostRenderCallback */
 /** @typedef {() => { reduce?: Reducer, observe?: Observer, tick?: Ticker, post_render?: PostRenderCallback }} Module */
 /** @typedef {import("three").AnimationAction} AnimAction */
 
@@ -351,8 +351,8 @@ const MODULES = [
   game_audio,
   game_entities,
   game_terrain,
-  game_minimap,
   game_water,
+  game_minimap,
   game_connect,
   game_entites_stroll,
   game_damage_ui,
@@ -711,7 +711,7 @@ function animate() {
     modules
       .map(({ post_render }) => post_render)
       .filter(Boolean)
-      .forEach(post_render => post_render(context))
+      .forEach(post_render => post_render(state, context))
 
     const next_frame_duration = 1000 / state.settings.target_fps
 

--- a/src/core/game/rendering/underwater_pass.js
+++ b/src/core/game/rendering/underwater_pass.js
@@ -1,5 +1,4 @@
 import {
-  Color,
   NoBlending,
   PerspectiveCamera,
   RawShaderMaterial,
@@ -20,8 +19,6 @@ class UnderwaterPass extends Pass {
 
     this.#camera = new PerspectiveCamera()
     this.needsSwap = true
-
-    this.color = new Color(0x3f7be2)
 
     const noise = `//	Simplex 3D Noise 
     //	by Ian McEwan, Ashima Arts
@@ -104,7 +101,6 @@ class UnderwaterPass extends Pass {
       depthWrite: false,
       uniforms: {
         uTexture: { value: null },
-        uColor: { value: this.color },
         uTime: { value: 0 },
         uAspectRatio: { value: 1 },
       },
@@ -119,7 +115,6 @@ class UnderwaterPass extends Pass {
       fragmentShader: `precision mediump float;
 
             uniform sampler2D uTexture;
-            uniform vec3 uColor;
             uniform float uTime;
             uniform float uAspectRatio;
 
@@ -143,7 +138,7 @@ class UnderwaterPass extends Pass {
                 uv = fract(vUv + dUv);
                 uv = clamp(uv, vec2(0), vec2(1));
 
-                gl_FragColor = vec4(uColor, 1) * texture2D(uTexture, uv);
+                gl_FragColor = texture2D(uTexture, uv);
             }`,
     })
 
@@ -162,11 +157,6 @@ class UnderwaterPass extends Pass {
 
     renderer.setRenderTarget(this.renderToScreen ? null : write_buffer)
     this.#material.uniforms.uTexture.value = read_buffer.texture
-    this.#material.uniforms.uColor.value = new Color().lerpColors(
-      this.color,
-      new Color(0xffffff),
-      0.15,
-    )
     this.#material.uniforms.uTime.value = performance.now() / 3000
     this.#material.uniforms.uAspectRatio.value =
       read_buffer.width / read_buffer.height

--- a/src/core/modules/game_camera.js
+++ b/src/core/modules/game_camera.js
@@ -15,7 +15,11 @@ const CAMERA_MAX_DISTANCE = 50
 /** @type {Type.Module} */
 export default function () {
   return {
-    tick(state, { camera_controls, dispatch, camera, physics }, delta) {
+    tick(
+      state,
+      { camera_controls, dispatch, camera, physics, voxel_engine },
+      delta,
+    ) {
       const player = current_three_character(state)
       if (!player?.position) return
 
@@ -40,7 +44,8 @@ export default function () {
       }
       camera_controls.update(delta)
 
-      const is_underwater = camera.position.y <= world_settings.getSeaLevel()
+      const is_underwater =
+        camera.position.y <= voxel_engine.water_data.map.waterLevel
       if (camera_state.is_underwater !== is_underwater) {
         dispatch('action/camera_went_underwater', is_underwater)
       }

--- a/src/core/modules/game_lights.js
+++ b/src/core/modules/game_lights.js
@@ -68,18 +68,17 @@ export default function () {
       }
 
       function update_fog(camera_is_underwater, color) {
-        scene.fog.color = color.clone()
+        camera.far = camera_is_underwater ? 250 : 3000
+        // @ts-ignore
+        const /** @type import('three').Fog */ scene_fog = scene.fog
+
+        scene_fog.color = color.clone()
         if (camera_is_underwater) {
-          // @ts-ignore
-          scene.fog.near = 0
-          // @ts-ignore
-          scene.fog.far = 0.2 * camera.far
+          scene_fog.near = 0
         } else {
-          // @ts-ignore
-          scene.fog.near = 0.25 * camera.far
-          // @ts-ignore
-          scene.fog.far = 0.98 * camera.far
+          scene_fog.near = 0.25 * camera.far
         }
+        scene_fog.far = 0.98 * camera.far
       }
 
       aiter(abortable(typed_on(events, 'STATE_UPDATED', { signal }))).reduce(

--- a/src/core/modules/game_minimap.js
+++ b/src/core/modules/game_minimap.js
@@ -45,7 +45,7 @@ export default function () {
       window.addEventListener('resize', update_screen_position, { signal })
       update_screen_position()
     },
-    post_render({ renderer, voxel_engine }) {
+    post_render(_, { renderer, voxel_engine }) {
       voxel_engine.minimap.render(renderer)
     },
   }

--- a/src/core/modules/game_render.js
+++ b/src/core/modules/game_render.js
@@ -205,8 +205,9 @@ export default function () {
 
             volumetric_fog_pass.enabled =
               postprocessing.volumetric_fog_pass.enabled
-            volumetric_fog_pass.uniformity =
-              postprocessing.volumetric_fog_pass.uniformity
+            volumetric_fog_pass.uniformity = camera_is_underwater
+              ? 0.75
+              : postprocessing.volumetric_fog_pass.uniformity
             volumetric_fog_pass.smoothness =
               postprocessing.volumetric_fog_pass.smoothness
             volumetric_fog_pass.fog_density =

--- a/src/core/modules/game_render.js
+++ b/src/core/modules/game_render.js
@@ -233,12 +233,6 @@ export default function () {
               postprocessing.underwater_pass.enabled && camera_is_underwater
           }
 
-          const water_color = state.settings.water.color
-          if (!last_water_color || !last_water_color.equals(water_color)) {
-            last_water_color = water_color
-            underwater_pass.color = last_water_color
-          }
-
           const lights_changed =
             state.settings.sky.lights.version !== last_sky_lights_version
           if (lights_changed) {

--- a/src/core/modules/game_weather.js
+++ b/src/core/modules/game_weather.js
@@ -121,15 +121,22 @@ export default function () {
   }
 
   return {
-    tick(_state, { renderer, camera }) {
-      if (snow.container.parent && snow.container.visible) {
-        snow.update(renderer, camera)
-      }
-      if (rain.container.parent && rain.container.visible) {
-        rain.update(renderer, camera)
+    tick(state, { renderer, camera, voxel_engine }) {
+      weather_container.visible = !state.settings.camera.is_underwater
+
+      if (weather_container.visible) {
+        snow.clippingPlaneLevel = voxel_engine.water_data.map.waterLevel
+        rain.clippingPlaneLevel = voxel_engine.water_data.map.waterLevel
+
+        if (snow.container.visible) {
+          snow.update(renderer, camera)
+        }
+        if (rain.container.visible) {
+          rain.update(renderer, camera)
+        }
       }
     },
-    observe({ scene, renderer, signal, events }) {
+    observe({ scene, signal }) {
       weather_container.name = 'weather-container'
       scene.add(weather_container)
 
@@ -139,9 +146,8 @@ export default function () {
       weather_container.add(rain.container)
       rain.setParticlesCount(5000)
 
-      weather_container.layers.set(CartoonRenderpass.non_outlined_layer)
-      weather_container.traverse(child => {
-        child.layers.set(CartoonRenderpass.non_outlined_layer)
+      weather_container.traverse(object => {
+        object.layers.set(CartoonRenderpass.non_outlined_layer)
       })
 
       snow.container.visible = false

--- a/src/core/modules/ui_fps.js
+++ b/src/core/modules/ui_fps.js
@@ -69,14 +69,23 @@ export default function () {
     return count
   }
 
+  let last_ui_update = -1
+
   return {
     tick(state, { scene, renderer }) {
-      stats_entities.update()
       stats_fps.update()
-      stats_memory.update()
-      mesh_panel.update(count_meshes(scene), 1000) // 1000 is an arbitrary max value
-      draw_calls_panel.update(renderer.info.render.calls, 5000) // 5000 is an arbitrary max value for draw calls
-      entity_panel.update(get_spawned_entities_count(state), 1000) // 1000 is an arbitrary max value for entities
+
+      const now = performance.now()
+      if (now - last_ui_update > 100) {
+        // don't update these too often to avoid taking too much CPU
+        last_ui_update = now
+
+        mesh_panel.update(count_meshes(scene), 1000) // 1000 is an arbitrary max value
+        draw_calls_panel.update(renderer.info.render.calls, 5000) // 5000 is an arbitrary max value for draw calls
+        entity_panel.update(get_spawned_entities_count(state), 1000) // 1000 is an arbitrary max value for entities
+        stats_entities.update()
+        stats_memory.update()
+      }
     },
     reduce(state, { type, payload }) {
       if (type === 'action/show_fps') {


### PR DESCRIPTION
This PR contains:
- a fix for a bug where when postprocessing was disabled, the colors were normal when underwater (they should be blueish)
- a fix for a bug where there was snow / rain when underwater
- a perf optim where the various UI indicators (meshes, draw calls, memory etc.) were taking up to 8% of the CPU, they now take 4% (which is way better but still a lot)
- a perf optim where the far plane is reduced when underwater (the fog density was already increased, so the view distance was  alreayd lowered)
- an improvement of the colors when underwater